### PR TITLE
App scrapping updated to new markup

### DIFF
--- a/src/Scraper.php
+++ b/src/Scraper.php
@@ -152,7 +152,7 @@ class Scraper
         $info['screenshots'] = $crawler->filter('[data-screenshot-item-index]')->each(function ($node) {
             return $this->getAbsoluteUrl($node->filter('img')->attr('src'));
         });
-        $desc = $this->cleanDescription($crawler->filter('[itemprop="description"] > content > div'));
+        $desc = $this->cleanDescription($crawler->filter('[itemprop="description"] > span > div'));
         $info['description'] = $desc['text'];
         $info['description_html'] = $desc['html'];
         $ratingNode = $crawler->filter('.BHMmbe');


### PR DESCRIPTION
Google Play have changed the html markup and the scraper doesn't work anymore.
Now the description has a span tag instead of the previous content tab.

With this change the scraper will work again.

Thanks! 