### PR TITLE
Fix: Call to undefined method Response::getStatus()

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -12,7 +12,7 @@ class Client extends BaseClient
         $content = str_replace(chr(0), '', $response->getContent());
         $newResponse = new Response(
             $content,
-            $response->getStatus(),
+            $response->getStatusCode(),
             $response->getHeaders()
         );
 

--- a/src/Scraper.php
+++ b/src/Scraper.php
@@ -365,7 +365,7 @@ class Scraper
             $url .= '?'.$query;
         }
         $crawler = $this->client->request('GET', $url);
-        $status_code = $this->client->getResponse()->getStatus();
+        $status_code = $this->client->getResponse()->getStatusCode();
         if ($status_code == 404) {
             throw new NotFoundException('Requested resource not found');
         } elseif ($status_code != 200) {


### PR DESCRIPTION
Replace the Response::getStatus() with the newest Response::getStatusCode() to fix the Call to undefined method Response::getStatus() in the line 15 of Client.php and the line 368 of Scraper.php.