### PR TITLE
Change getStatus() to getStatusCode() in Client.php

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -12,7 +12,7 @@ class Client extends BaseClient
         $content = str_replace(chr(0), '', $response->getContent());
         $newResponse = new Response(
             $content,
-            $response->getStatus(),
+            $response->getStatusCode(),
             $response->getHeaders()
         );
 


### PR DESCRIPTION
According to issue #27
`Symfony\Component\BrowserKit\Response::getStatus()` was deprecated since v4.3 and was removed in v5.0. The `getStatusCode()` method must be used in newest library versions.