### PR TITLE
Change getStatus() to getStatusCode() in Scraper.php

### DIFF
--- a/src/Scraper.php
+++ b/src/Scraper.php
@@ -365,7 +365,7 @@ class Scraper
             $url .= '?'.$query;
         }
         $crawler = $this->client->request('GET', $url);
-        $status_code = $this->client->getResponse()->getStatus();
+        $status_code = $this->client->getResponse()->getStatusCode();
         if ($status_code == 404) {
             throw new NotFoundException('Requested resource not found');
         } elseif ($status_code != 200) {


### PR DESCRIPTION
According to issue #27
`Symfony\Component\BrowserKit\Response::getStatus()` was deprecated since v4.3 and was removed in v5.0. The `getStatusCode()` method must be used in newest library versions.